### PR TITLE
Improve robustness and usablity of release-tools (SOFTWARE-2216)

### DIFF
--- a/0-generate-pkg-list
+++ b/0-generate-pkg-list
@@ -52,4 +52,7 @@ for ver in ${versions[@]}; do
     done
 done
 
-cleanup_on_success
+# Don't remove rescue files if user is troubleshooting
+if [ $DRY_RUN -eq 0 ]; then
+    cleanup_on_success
+fi

--- a/1-client-tarballs
+++ b/1-client-tarballs
@@ -36,3 +36,8 @@ for ver in ${versions[@]}; do
 done
 
 popd
+
+# Don't remove rescue files if user is troubleshooting
+if [ $DRY_RUN -eq 0 ]; then
+    cleanup_on_success
+fi

--- a/1-verify-prerelease
+++ b/1-verify-prerelease
@@ -39,5 +39,3 @@ else
 fi
 
 rm prerelease slated
-
-cleanup_on_success

--- a/2-create-release
+++ b/2-create-release
@@ -31,7 +31,6 @@ for ver in ${versions[@]}; do
         print_header "Moving packages from $prerelease_repo to $release_repo"
         run_cmd "osg-koji list-tagged --quiet $prerelease_repo | awk '{print \$1}' > move-to-$branch-release-$dver"
         run_cmd "xargs --arg-file move-to-$branch-release-$dver osg-koji move-pkg $prerelease_repo $release_repo"
-
         echo
 
         # Create new release repo
@@ -43,7 +42,8 @@ for ver in ${versions[@]}; do
         # Lock repos
         print_header "Locking $release_repo"
         run_cmd "osg-koji edit-tag --lock $release_repo"
-        print_header "\nLocking $versioned_release_repo"
+        echo
+        print_header "Locking $versioned_release_repo"
         run_cmd "osg-koji edit-tag --lock $versioned_release_repo"
         echo
 

--- a/2-create-release
+++ b/2-create-release
@@ -53,8 +53,8 @@ for ver in ${versions[@]}; do
         echo
 
         # Write release notes
-        run_cmd "awk '{ print \"   * [[https://koji-hub.batlab.org/koji/search?match=glob&type=build&terms=\" \$1 \"][\" \$1 \"]]\"}' move-to-$branch-release-$dver > $branch-release-note-packages-$dver"
-         run_cmd "xargs --arg-file move-to-$branch-release-$dver osg-koji buildinfo | fgrep \"/mnt\" | xargs -n 1 basename | perl -p -e \"s/\.(noarch|src|i386|x86_64)\.rpm//\" | sort -u > $branch-release-note-rpms-$dver"
+        awk '{ print "   * [[https://koji-hub.batlab.org/koji/search?match=glob&type=build&terms=" $1 "][" $1 "]]"}' move-to-$branch-release-$dver > $branch-release-note-packages-$dver
+        xargs --arg-file move-to-$branch-release-$dver osg-koji buildinfo | fgrep "/mnt" | xargs -n 1 basename | perl -p -e "s/\.(noarch|src|i386|x86_64)\.rpm//" | sort -u > $branch-release-note-rpms-$dver
 
         # Update info
         run_cmd "cp move-to-$branch-release-$dver $ver-updated-$branch-$dver.txt"

--- a/2-create-release
+++ b/2-create-release
@@ -60,6 +60,9 @@ for ver in ${versions[@]}; do
         run_cmd "cp move-to-$branch-release-$dver $ver-updated-$branch-$dver.txt"
         run_cmd "osg-koji list-tagged --quiet --latest $release_repo | awk '{print \$1}' > $ver-packages-$branch-$dver.txt"
         run_cmd "xargs --arg-file $ver-packages-$branch-$dver.txt osg-koji buildinfo | fgrep \"/mnt\" | xargs -n 1 basename | sort > $ver-rpms-$branch-$dver.txt"
+
+        # Copy release info files over to AFS
+        print_header "Copying files over to UW's AFS"
         if [ -d /p/vdt/public/html/release-info/ ]; then
             run_cmd "cp $ver-updated-$branch-$dver.txt $ver-packages-$branch-$dver.txt $ver-rpms-$branch-$dver.txt /p/vdt/public/html/release-info/"
         else

--- a/2-create-release
+++ b/2-create-release
@@ -60,17 +60,18 @@ for ver in ${versions[@]}; do
         run_cmd "cp move-to-$branch-release-$dver $ver-updated-$branch-$dver.txt"
         run_cmd "osg-koji list-tagged --quiet --latest $release_repo | awk '{print \$1}' > $ver-packages-$branch-$dver.txt"
         run_cmd "xargs --arg-file $ver-packages-$branch-$dver.txt osg-koji buildinfo | fgrep \"/mnt\" | xargs -n 1 basename | sort > $ver-rpms-$branch-$dver.txt"
-
-        # Copy release info files over to AFS
-        print_header "Copying files over to UW's AFS"
-        if [ -d /p/vdt/public/html/release-info/ ]; then
-            run_cmd "cp $ver-updated-$branch-$dver.txt $ver-packages-$branch-$dver.txt $ver-rpms-$branch-$dver.txt /p/vdt/public/html/release-info/"
-        else
-            run_cmd "scp $ver-updated-$branch-$dver.txt $ver-packages-$branch-$dver.txt $ver-rpms-$branch-$dver.txt $rusermachine:/p/vdt/public/html/release-info/"
-        fi
         echo
     done
 done
+
+# Copy release info files over to AFS
+release_files=awk '/\.txt$/ {print $NF}' $rescue_file
+print_header "Copying files over to UW's AFS"
+if [ -d /p/vdt/public/html/release-info/ ]; then
+    run_cmd "cp $release_files /p/vdt/public/html/release-info/"
+else
+    run_cmd "scp $release_files $rusermachine:/p/vdt/public/html/release-info/"
+fi
 
 # Don't remove rescue files if user is troubleshooting
 if [ $DRY_RUN -eq 0 ]; then

--- a/2-create-release
+++ b/2-create-release
@@ -72,4 +72,7 @@ for ver in ${versions[@]}; do
     done
 done
 
-cleanup_on_success
+# Don't remove rescue files if user is troubleshooting
+if [ $DRY_RUN -eq 0 ]; then
+    cleanup_on_success
+fi

--- a/2-create-release
+++ b/2-create-release
@@ -55,6 +55,11 @@ for ver in ${versions[@]}; do
         # Write release notes
         awk '{ print "   * [[https://koji-hub.batlab.org/koji/search?match=glob&type=build&terms=" $1 "][" $1 "]]"}' move-to-$branch-release-$dver > $branch-release-note-packages-$dver
         xargs --arg-file move-to-$branch-release-$dver osg-koji buildinfo | fgrep "/mnt" | xargs -n 1 basename | perl -p -e "s/\.(noarch|src|i386|x86_64)\.rpm//" | sort -u > $branch-release-note-rpms-$dver
+        if [[ $branch == 'upcoming' ]]; then
+            list-package-updates -u $ver > $branch-release-note-rpm-updates-$dver
+        else
+            list-package-updates $ver > $branch-release-note-rpm-updates-$dver
+        fi
 
         # Update info
         run_cmd "cp move-to-$branch-release-$dver $ver-updated-$branch-$dver.txt"


### PR DESCRIPTION
Breaking up my PR into multiple requests for easier review (review in numerical order, 5/5). This PR includes:
- Some code tidying commits
- Streamlining scp/cp of `release-info` files at the end of the day 2 script
- Don't keep track of release-note generation files
- Add release-note RPM updates file (i.e. the output from `list-package-updates`
