### PR TITLE
Fix issue where all tarballs were being generated for both i386 and x…

### DIFF
--- a/1-client-tarballs
+++ b/1-client-tarballs
@@ -28,12 +28,11 @@ versions=(${versions[@]/upcoming/})
 for ver in ${versions[@]}; do
     branch=$(osg_release $ver)
     print_header "Generating $branch tarballs"
+    run_cmd "/tmp/tarball-client/make-client-tarball --osgver=$branch --all --prerelease"
     for arch in i386 x86_64; do
         tarball_dir="tarballs/$branch/$arch"
-        mkdir -p $tarball_dir
-        pushd $tarball_dir
-        run_cmd "/tmp/tarball-client/make-client-tarball --osgver=$branch --prerelease --all"
-        popd
+        run_cmd "mkdir -p $tarball_dir"
+        run_cmd "mv osg*client-$branch*$arch*.tar.gz $tarball_dir"
     done
 done
 


### PR DESCRIPTION
…86_64
### Before

```
# find /tmp/tarballs -name \*.tar.gz -ls
388070 26776 -rw-r--r--   1 root     root     27382771 Sep 11 16:29 /tmp/tarballs/3.3/i386/osg-wn-client-3.3.16-1.el6.i386.tar.gz
387914 34716 -rw-r--r--   1 root     root     35506938 Sep 11 16:36 /tmp/tarballs/3.3/i386/osg-wn-client-3.3.16-1.el7.x86_64.tar.gz
387485 36180 -rw-r--r--   1 root     root     37005071 Sep 11 16:43 /tmp/tarballs/3.3/i386/osg-afs-client-3.3.16-1.el7.x86_64.tar.gz
388142 26884 -rw-r--r--   1 root     root     27495662 Sep 11 16:32 /tmp/tarballs/3.3/i386/osg-wn-client-3.3.16-1.el6.x86_64.tar.gz
388561 28324 -rw-r--r--   1 root     root     28968117 Sep 11 16:39 /tmp/tarballs/3.3/i386/osg-afs-client-3.3.16-1.el6.x86_64.tar.gz
388102 26772 -rw-r--r--   1 root     root     27380524 Sep 11 16:46 /tmp/tarballs/3.3/x86_64/osg-wn-client-3.3.16-1.el6.i386.tar.gz
387373 34716 -rw-r--r--   1 root     root     35507401 Sep 11 16:53 /tmp/tarballs/3.3/x86_64/osg-wn-client-3.3.16-1.el7.x86_64.tar.gz
388648 36180 -rw-r--r--   1 root     root     37006101 Sep 11 17:00 /tmp/tarballs/3.3/x86_64/osg-afs-client-3.3.16-1.el7.x86_64.tar.gz
388136 26884 -rw-r--r--   1 root     root     27495532 Sep 11 16:50 /tmp/tarballs/3.3/x86_64/osg-wn-client-3.3.16-1.el6.x86_64.tar.gz
388565 28324 -rw-r--r--   1 root     root     28969201 Sep 11 16:57 /tmp/tarballs/3.3/x86_64/osg-afs-client-3.3.16-1.el6.x86_64.tar.gz 
```
### After

```
# find /tmp/tarballs -name \*.tar.gz -ls 
 32790 26776 -rw-r--r--   1 root     root     27383255 Sep 12 15:33 /tmp/tarballs/3.3/i386/osg-wn-client-3.3.16-1.el6.i386.tar.gz
 32779 34716 -rw-r--r--   1 root     root     35507458 Sep 12 15:40 /tmp/tarballs/3.3/x86_64/osg-wn-client-3.3.16-1.el7.x86_64.tar.gz
 32794 36180 -rw-r--r--   1 root     root     37004948 Sep 12 15:48 /tmp/tarballs/3.3/x86_64/osg-afs-client-3.3.16-1.el7.x86_64.tar.gz
 32777 26884 -rw-r--r--   1 root     root     27495241 Sep 12 15:37 /tmp/tarballs/3.3/x86_64/osg-wn-client-3.3.16-1.el6.x86_64.tar.gz
 32795 28324 -rw-r--r--   1 root     root     28969236 Sep 12 15:44 /tmp/tarballs/3.3/x86_64/osg-afs-client-3.3.16-1.el6.x86_64.tar.gz
```
