### PR TITLE
Support data-only releases

### DIFF
--- a/2-create-release
+++ b/2-create-release
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Unlock the release repos and move the pre-release packages into them.
-# Create a version-specific release tag
-# Lock and regenerate the release repos
+# Create a version-specific release tag (for non-data-only releases)
+# Lock the release repos
 # Write release notes and update information on UW's AFS
 
 . release-common.sh

--- a/2-create-release
+++ b/2-create-release
@@ -24,6 +24,11 @@ for ver in ${versions[@]}; do
         prerelease_repo=osg-$branch-$dver-prerelease
         release_repo=osg-$branch-$dver-release
 
+        # Write data-specific release notes
+        if [ $DATA -eq 1 ]; then
+            branch=$branch-data
+        fi
+
         # Push from pre-release to release
         print_header "Unlocking $release_repo"
         run_cmd "osg-koji edit-tag --unlock $release_repo"
@@ -34,24 +39,21 @@ for ver in ${versions[@]}; do
         run_cmd "xargs --arg-file move-to-$branch-release-$dver osg-koji move-pkg $prerelease_repo $release_repo"
         echo
 
-        # Create new release repo
-        versioned_release_repo=osg-$branch-$dver-release-$ver
-        print_header "Cloning $release_repo to $versioned_release_repo"
-        run_cmd "osg-koji clone-tag $release_repo $versioned_release_repo"
-        echo
+        if [ $DATA -eq 0 ]; then
+            # Create new release repo for non-data releases
+            versioned_release_repo=osg-$branch-$dver-release-$ver
+            print_header "Cloning $release_repo to $versioned_release_repo"
+            run_cmd "osg-koji clone-tag $release_repo $versioned_release_repo"
+            echo
+        fi
 
-        # Lock repos
-        print_header "Locking $release_repo"
-        run_cmd "osg-koji edit-tag --lock $release_repo"
-        echo
-        print_header "Locking $versioned_release_repo"
-        run_cmd "osg-koji edit-tag --lock $versioned_release_repo"
-        echo
-
-        # Regen repos
-        print_header "Regenerating $versioned_release_repo"
-        run_cmd "osg-koji regen-repo --nowait $versioned_release_repo"
-        echo
+        # Lock repos (data-only releases leave the versioned repos untouched
+        # for historical integrity)
+        for repo in $release_repo $versioned_release_repo; do
+            print_header "Locking $repo"
+            run_cmd "osg-koji edit-tag --lock $repo"
+            echo
+        done
 
         # Write release notes
         awk '{ print "   * [[https://koji-hub.batlab.org/koji/search?match=glob&type=build&terms=" $1 "][" $1 "]]"}' move-to-$branch-release-$dver > $branch-release-note-packages-$dver
@@ -65,7 +67,7 @@ for ver in ${versions[@]}; do
     done
 
     # RPM update release-notes don't need to specify the dver
-    if [[ $branch == 'upcoming' ]]; then
+    if [[ $branch =~ .*upcoming.* ]]; then
         list-package-updates -u $ver > $branch-release-note-rpm-updates
     else
         list-package-updates $ver > $branch-release-note-rpm-updates

--- a/release-common.sh
+++ b/release-common.sh
@@ -6,10 +6,14 @@ die () {
 }
 
 usage () {
-    echo "usage: `basename $0` [options] <VERSION 1> [<VERSION 2>...<VERSION N>]"
+    script_name=`basename $original_cmd`
+    echo "usage: $script_name [options] <VERSION 1> [<VERSION 2>...<VERSION N>]"
     echo "Options:"
-    echo -e "\t-h, --help\tPrint this message"
+    if [[ $script_name == "2-create-release" ]]; then
+        echo -e "\t-d, --data\tPerform a data-only release"
+    fi
     echo -e "\t-n, --dry-run\tPrint the commands that would be run"
+    echo -e "\t-h, --help\tPrint this message"
 }
 
 print_header () {
@@ -80,18 +84,19 @@ pkg_dist () {
     fi
 }
 
-if [ $# -lt 1 ]; then
-    usage
-    die
-fi
-
 ########
 # MAIN #
 ########
 
 DRY_RUN=0
+DATA=0
 versions=()
 original_cmd=$0
+
+if [ $# -lt 1 ]; then
+    usage
+    die
+fi
 
 while [ $# -ne 0 ];
 do
@@ -103,6 +108,14 @@ do
         -n|--dry-run)
             DRY_RUN=1
             shift
+            ;;
+        -d|--data)
+            if [[ $original_cmd != "2-create-release" ]]; then
+                usage
+                die "unknown option: $1"
+            else
+                $DATA=1
+            fi
             ;;
         -*)
             usage


### PR DESCRIPTION
`2-create-release` should be the only package that needs updating. Users will still need to specify the versions for which they're releasing.
