### PR TITLE
Fix bug where we attempted to tag osg-version into osg-release

### DIFF
--- a/0-generate-pkg-list
+++ b/0-generate-pkg-list
@@ -12,11 +12,12 @@ detect_rescue_file
 for ver in ${versions[@]/upcoming/}; do # We don't build osg-version for upcoming
     read -ra dvers <<< $(osg_dvers $ver) # create array of dvers
     for dver in "${dvers[@]}"; do
-        for repo in release testing prerelease; do
+        for repo in testing prerelease; do
             tag=osg-$(osg_release $ver)-$dver-$repo
+            versioned_tag=osg-$(osg_release $ver)-$dver-release-$ver
             # If there is already a versioned release tag, we don't
             # have to worry about tagging osg-version
-            osg-koji list-tagged $tag-$ver > /dev/null 2>&1 && break
+            osg-koji list-tagged $versioned_tag > /dev/null 2>&1 && break
 
             pkg=osg-version-$ver-1.$(pkg_dist $ver $dver)
             osg-koji latest-pkg $tag osg-version | grep $pkg > /dev/null


### PR DESCRIPTION
'release' was included in the repo for loop so that it could break early
in the case that osg-version was already tagged into a versioned release
repo but otherwise it attempted to tag osg-version into
osg-release.

We really need to sort out the game plan for data-only releases. Are we going to have different revs each time we do a data release? What does this mean for the tarballs when we have CA-only data releases and don't have to create new tarballs? Is it possible to update VO info without updating the tarballs as well? If so, we don't have to do rev numbers.