### PR TITLE
Skip promoting osg-version for data releases

### DIFF
--- a/0-generate-pkg-list
+++ b/0-generate-pkg-list
@@ -8,30 +8,34 @@ detect_rescue_file
 ##################################
 # Promote osg-version to testing #
 ##################################
+promote_osg_version() {
+    for ver in ${versions[@]/upcoming/}; do # We don't build osg-version for upcoming
+        read -ra dvers <<< $(osg_dvers $ver) # create array of dvers
+        for dver in "${dvers[@]}"; do
+            for repo in testing prerelease; do
+                tag=osg-$(osg_release $ver)-$dver-$repo
+                versioned_tag=osg-$(osg_release $ver)-$dver-release-$ver
+                # If there is already a versioned release tag, we don't
+                # have to worry about tagging osg-version
+                osg-koji list-tagged $versioned_tag > /dev/null 2>&1 && break
 
-for ver in ${versions[@]/upcoming/}; do # We don't build osg-version for upcoming
-    read -ra dvers <<< $(osg_dvers $ver) # create array of dvers
-    for dver in "${dvers[@]}"; do
-        for repo in testing prerelease; do
-            tag=osg-$(osg_release $ver)-$dver-$repo
-            versioned_tag=osg-$(osg_release $ver)-$dver-release-$ver
-            # If there is already a versioned release tag, we don't
-            # have to worry about tagging osg-version
-            osg-koji list-tagged $versioned_tag > /dev/null 2>&1 && break
-
-            pkg=osg-version-$ver-1.$(pkg_dist $ver $dver)
-            osg-koji latest-pkg $tag osg-version | grep $pkg > /dev/null
-            if [ $? -eq 1 ]; then
-                print_header "Promoting $pkg into $tag..."
-                run_cmd "osg-koji tag-pkg $tag $pkg"
-            else
-                print_header "$pkg already tagged in $tag"
-            fi
+                pkg=osg-version-$ver-1.$(pkg_dist $ver $dver)
+                osg-koji latest-pkg $tag osg-version | grep $pkg > /dev/null
+                if [ $? -eq 1 ]; then
+                    print_header "Promoting $pkg into $tag..."
+                    run_cmd "osg-koji tag-pkg $tag $pkg"
+                else
+                    print_header "$pkg already tagged in $tag"
+                fi
+            done
         done
     done
-done
+    echo
+}
 
-echo
+if [[ $DATA -eq 0 ]]; then
+    promote_osg_version
+fi
 
 # #############################
 # # Generate list of packages #

--- a/release-common.sh
+++ b/release-common.sh
@@ -6,10 +6,9 @@ die () {
 }
 
 usage () {
-    script_name=`basename $original_cmd`
     echo "usage: $script_name [options] <VERSION 1> [<VERSION 2>...<VERSION N>]"
     echo "Options:"
-    if [[ $script_name == "2-create-release" ]]; then
+    if [[ $script_name == "2-create-release" ]] || [[ $script_name == "0-generate-pkg-list" ]]; then
         echo -e "\t-d, --data\tPerform a data-only release"
     fi
     echo -e "\t-n, --dry-run\tPrint the commands that would be run"
@@ -66,13 +65,13 @@ check_file_transfer_rc () {
     # Exit script if files fail to copy over so we can use the rescue file
     # mechanism to resend the files
     if [ $1 -ne 0 ]; then
-        echo -e "\033[1;31mFailed to copy release notes to AFS. Re-run $original_cmd\033[0m"
+        echo -e "\033[1;31mFailed to copy release notes to AFS. Re-run $script_name\033[0m"
         exit 1
     fi
 }
 
 detect_rescue_file () {
-    rescue_file=`pwd`/$original_cmd.rescue
+    rescue_file=`pwd`/$script_name.rescue
     [ -e $rescue_file ] && print_header "Found rescue file, picking up after the last successful command...\n" \
             || touch $rescue_file
 }
@@ -100,7 +99,7 @@ pkg_dist () {
 DRY_RUN=0
 DATA=0
 versions=()
-original_cmd=$0
+script_name=$(basename $0)
 
 if [ $# -lt 1 ]; then
     usage
@@ -119,7 +118,7 @@ do
             shift
             ;;
         -d|--data)
-            if [[ $original_cmd =~ .*2-create-release ]]; then
+            if [[ $script_name == "2-create-release" ]] || [[ $script_name == "0-generate-pkg-list" ]]; then
                 DATA=1
                 shift
             else


### PR DESCRIPTION
This should let you generate the package list for tomorrow. The commit also includes a small change to get the script name via `basename` so we don't have to worry about how the user runs the script.