### PR TITLE
introduce '--since' option for data releases (SOFTWARE-2578)

### DIFF
--- a/list-package-updates
+++ b/list-package-updates
@@ -2,11 +2,17 @@
 set -e
 
 usage () {
-  echo "usage: $(basename "$0") [--bare] [-u|--upcoming] 3.X.Y [3.X.Z]"
-  echo "   eg: $(basename "$0") 3.2.7 3.2.8"
+  script=$(basename "$0")
+  echo "usage: $script [--bare] [-u|--upcoming] 3.X.Y [3.X.Z]"
+  echo "   or: $script [--bare] [-u|--upcoming] --since 3.X.Y"
+  echo
+  echo "   eg: $script 3.2.7 3.2.8       # compare two releases"
+  echo "   or: $script 3.2.8             # implicitly compare to 3.2.7"
+  echo "   or: $script --since 3.3.20    # compare to current release"
   echo
   echo "Lists packages updated from osg releases 3.X.Y to 3.X.Z"
   echo "If only one osg release is listed, compare to the previous release."
+  echo "If --since is given, compare to current release (for data releases)."
   echo
   echo "Use --upcoming to list packages from osg-upcoming-release-3.X.Y repos."
   echo "Use --bare to list 1 package per line, without wrapping in <pre> tags."
@@ -32,8 +38,10 @@ pre_wrap () {
 
 FILTER=pre_wrap
 SERIES=
+SINCE=
 while [[ $1 = -* ]]; do
 case $1 in
+  --since       ) SINCE=Y;         shift;;
   --bare        ) FILTER=cat;      shift;;
   -u|--upcoming ) SERIES=upcoming; shift;;
              -* ) echo "Unsupported option: $1" >&2; usage ;;
@@ -42,20 +50,29 @@ done
 
 case $# in
   1 ) [[ $1 =~ ^[3-9]\.[0-9]\.[0-9]+$ ]] || usage
-      ser=${1%.*}
+      ser1=${1%.*}
+      ser2=$ser1
       rel=${1##*.}
-      v1=$ser.$((rel-1))
-      v2=$1 ;;
-  2 ) [[ $1 =~ ^[3-9]\.[0-9]\.[0-9]+$ ]] || usage
+      if [[ $SINCE ]]; then
+        v1=$1
+        v2=
+      else
+        v1=$ser1.$((rel-1))
+        v2=$1
+      fi ;;
+  2 ) [[ ! $SINCE ]] || usage
+      [[ $1 =~ ^[3-9]\.[0-9]\.[0-9]+$ ]] || usage
       [[ $2 =~ ^[3-9]\.[0-9]\.[0-9]+$ ]] || usage
+      ser1=${1%.*}
+      ser2=${2%.*}
       v1=$1
       v2=$2 ;;
   * ) usage ;;
 esac
 
 for dver in ${dvers[@]}; do
-  tag1=osg-${SERIES:-${v1%.*}}-$dver-release-$v1
-  tag2=osg-${SERIES:-${v2%.*}}-$dver-release-$v2
+  tag1=osg-${SERIES:-$ser1}-$dver-release-$v1
+  tag2=osg-${SERIES:-$ser2}-$dver-release${v2:+-$v2}
   tag_diff $tag1 $tag2
 done | perl -lpe 's/(-[^-]+){2}$//' | sort -u | $FILTER
 


### PR DESCRIPTION
As discussed today, this option allows comparing a given release
version to the current (unversioned) release.  It is intended for
data releases, which currently do not have *-release-X.Y.Z koji tags.

The usage help is updated, but the new option is pretty straightforward:

```
$ ./list-package-updates --since 3.3.20
<pre>
igtf-ca-certs osg-ca-certs osg-gums-config vo-client vo-client-edgmkgridmap
</pre>
```