### PR TITLE
Don't try to rebuild upcoming build repos

### DIFF
--- a/1-regen-repos
+++ b/1-regen-repos
@@ -5,6 +5,9 @@
 . release-common.sh
 detect_rescue_file
 
+# drop upcoming from versions since they don't get their own tarballs
+versions=(${versions[@]/upcoming/})
+
 for ver in ${versions[@]}; do
     branch=$(osg_release $ver)
     read -ra dvers <<< $(osg_dvers $ver) # create array of dvers


### PR DESCRIPTION
1) we don't build tarballs from upcoming
2) upcoming build repos are named differently, e.g. osg-upcoming-el7-build