### PR TITLE
Fix AFS file update

### DIFF
--- a/2-create-release
+++ b/2-create-release
@@ -76,7 +76,7 @@ for ver in ${versions[@]}; do
 done
 
 # Copy release info files over to AFS
-release_files=`awk '/\.txt$/ {print $NF}' $rescue_file`
+release_files=`awk '/\.txt$/ {printf "%s ", $NF}' $rescue_file`
 print_header "Copying files over to UW's AFS"
 if [ -d /p/vdt/public/html/release-info/ ]; then
     run_cmd "cp $release_files /p/vdt/public/html/release-info/"

--- a/release-common.sh
+++ b/release-common.sh
@@ -46,6 +46,7 @@ run_cmd () {
     cmd=$1
     if [[ $DRY_RUN -eq 1 ]]; then
         echo "$cmd"
+        echo "$cmd" >> $rescue_file
     else
         grep -F "$cmd" $rescue_file > /dev/null 2>&1
         if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
Newlines in awk output screw up the cp command
Always write into the rescue file for debugging puposes