### PR TITLE
Fix text in output of 0-generate-pkg-list

### DIFF
--- a/0-generate-pkg-list
+++ b/0-generate-pkg-list
@@ -45,7 +45,7 @@ for ver in ${versions[@]}; do
     branch=$(osg_release $ver)
     read -ra dvers <<< $(osg_dvers $ver) # create array of dvers
     for dver in ${dvers[@]}; do
-        print_header "RPMs slated for release in osg-$branch-$dver-release"
+        print_header "RPMs slated for release in osg-$branch-$dver-testing"
         slated_cmd="koji-tag-diff osg-$branch-$dver-{testing,release}"
         slated=$(eval $slated_cmd | tail -n +2)
         if [[ $DRY_RUN -eq 1 ]]; then

--- a/release-common.sh
+++ b/release-common.sh
@@ -92,7 +92,7 @@ pkg_dist () {
 pkgs_to_release () {
     branch=$1
     dver=$2
-    awk "/^RPMs.*osg-$branch-$dver-release/ {flag=1;next} /^[[:space:]]*$/ { flag=0 } flag { print }" release-list
+    awk "/^RPMs.*osg-$branch-$dver-testing/ {flag=1;next} /^[[:space:]]*$/ { flag=0 } flag { print }" release-list
 }
 
 ########


### PR DESCRIPTION
@timtheisen after you merge this, you'll want to make sure the `release-list` has the relevant lines changed from `release` to `testing` so that the parser can correctly find the list of packages.