### PR TITLE
Use markdown format for release-notes files

### DIFF
--- a/2-create-release
+++ b/2-create-release
@@ -57,7 +57,7 @@ for ver in ${versions[@]}; do
         cp /dev/null $branch-release-note-packages-$dver
         for package in $(<move-to-$branch-release-$dver); do
             uri_package=${package//+/%2B}
-            echo "   * [[https://koji.chtc.wisc.edu/koji/search?match=glob&type=build&terms=$uri_package][$package]]" \
+            echo "-   [$package](https://koji.chtc.wisc.edu/koji/search?match=glob&type=build&terms=$uri_package)" \
                 >> $branch-release-note-packages-$dver
         done
         xargs --arg-file move-to-$branch-release-$dver osg-koji buildinfo | fgrep "/mnt" | \

--- a/list-package-updates
+++ b/list-package-updates
@@ -30,13 +30,12 @@ tag_diff () {
   fgrep -vxf <(list_tag "$1") <(list_tag "$2") || :
 }
 
-pre_wrap () {
-  echo '<pre>'
+indent () {
+  echo -n '    '
   xargs
-  echo '</pre>'
 }
 
-FILTER=pre_wrap
+FILTER=indent
 SERIES=
 SINCE=
 while [[ $1 = -* ]]; do


### PR DESCRIPTION
I made minor adjustments to the release-notes output to be able to cut and paste into the release notes pages.