### PR TITLE
Allow tagging docker image based on digest (SOFTWARE-3916)

### DIFF
--- a/dockerhub-tag-fresh-to-stable.sh
+++ b/dockerhub-tag-fresh-to-stable.sh
@@ -7,7 +7,7 @@ usage () {
   echo "arguments:"
   echo "  REPO:     '<owner>/<name>' eg 'opensciencegrid/frontier-squid'"
   echo "            (<owner> defaults to 'opensciencegrid' if omitted)"
-  echo "  OLD_TAG:  Either 'fresh' or <YYYYMMDD-HHMM>"
+  echo "  OLD_TAG:  Either 'fresh' or <YYYYMMDD-HHMM>, or a sha256:... digest"
   echo "  NEW_TAG:  Defaults to 'stable'"
   echo
   echo "Environment:"
@@ -18,6 +18,8 @@ usage () {
   exit
 }
 
+fail () { echo "$@" >&2; exit 1; }
+
 [[ $2 ]] || usage
 REPOSITORY=$1
 TAG_OLD=$2
@@ -26,6 +28,11 @@ TAG_NEW=${3:-stable}
 [[ $REPOSITORY = */* ]] || REPOSITORY=opensciencegrid/$REPOSITORY
 case $TAG_OLD in
   fresh | 20[1-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9] ) ;; # OK
+
+  *@sha256:* | sha256:* ) # OK - verify digest format
+      TAG_OLD=${TAG_OLD##*@}  # don't want docker-pullable:// URL
+      [[ $TAG_OLD =~ ^sha256:[0-9a-f]{64}$ ]] || usage ;;
+
   * ) usage ;;
 esac
 
@@ -48,11 +55,11 @@ TOKEN=$(
 )
 
 MANIFEST=$(
-  curl -s \
+  curl -s -S -f \
        -H "Accept: ${CONTENT_TYPE}" \
        -H "Authorization: Bearer $TOKEN" \
        "${REGISTRY}/v2/${REPOSITORY}/manifests/${TAG_OLD}"
-)
+) || fail "(Possibly bad tag/digest)"
 
 curl -X PUT \
      -H "Content-Type: ${CONTENT_TYPE}" \


### PR DESCRIPTION
Apparently we can just ask for the manifest for an image digest instead of a tag:
https://docs.docker.com/registry/spec/api/#get-manifest

The part that dockerhub cares about is the `sha256:...` digest. But since we apparently store Image IDs with the full `docker-pullable://<OWNER>/<REPO>@` prefix, accept this in the script also.

