### PR TITLE
Underline some of the headers for readability

### DIFF
--- a/0-generate-pkg-list
+++ b/0-generate-pkg-list
@@ -65,7 +65,7 @@ for ver in ${versions[@]}; do
     branch=$(osg_release $ver)
     read -ra dvers <<< $(osg_dvers $ver) # create array of dvers
     for dver in ${dvers[@]}; do
-        print_header "RPMs slated for release in osg-$branch-$dver-testing"
+        print_header_with_line "RPMs slated for release in osg-$branch-$dver-testing"
         slated_cmd="koji-tag-diff osg-$branch-$dver-{testing,release}"
         slated=$(eval $slated_cmd | tail -n +2)
         if [[ $DRY_RUN -eq 1 ]]; then
@@ -76,7 +76,7 @@ for ver in ${versions[@]}; do
         echo
 
         slist=$(echo "$slated" | perl -lpe 's/(-[^-]+){2}$//' | tr '\n' ' ')
-        print_header "Slated packages in testing behind current development versions"
+        print_header_with_line "Slated packages in testing behind current development versions"
         run_cmd "osg-pkgs-behind-tag osg-$branch-$dver-{testing,development} -- $slist"
         echo
     done

--- a/1-verify-prerelease
+++ b/1-verify-prerelease
@@ -32,13 +32,13 @@ for ver in ${versions[@]}; do
 
         # Print any slated packages missing from pre-release
         if [[ -n $missing_pkgs ]]; then
-            final_msg=$(printf "%s\n\n$(print_header "Slated packages missing from $prerel_tag")\n%s" \
+            final_msg=$(printf "%s\n\n$(print_header_with_line "Slated packages missing from $prerel_tag")\n%s" \
                         "$final_msg" "$missing_pkgs")
         fi
 
         # Print any packages in pre-release that are not slated for release
         if [[ -n $extra_pkgs ]]; then
-            final_msg=$(printf "%s\n\n$(print_header "Packages in $prerel_tag not slated for release")\n%s" \
+            final_msg=$(printf "%s\n\n$(print_header_with_line "Packages in $prerel_tag not slated for release")\n%s" \
                         "$final_msg" "$extra_pkgs")
         fi
     done

--- a/release-common.sh
+++ b/release-common.sh
@@ -18,12 +18,8 @@ print_header () {
 }
 
 print_header_with_line () {
-    echo -e "\033[1;33m$1\033[0m"
-    echo -en "\033[1;33m"
-    for ((i=0; i<${#1}; i++)); do
-        echo -n "="
-    done
-    echo -e "\033[0m"
+    print_header "$1"
+    print_header "$(tr '[:print:]' = <<< "$1")"
 }
 
 osg_release () {

--- a/release-common.sh
+++ b/release-common.sh
@@ -17,6 +17,15 @@ print_header () {
     echo -e "\033[1;33m$1\033[0m"
 }
 
+print_header_with_line () {
+    echo -e "\033[1;33m$1\033[0m"
+    echo -en "\033[1;33m"
+    for ((i=0; i<${#1}; i++)); do
+        echo -n "="
+    done
+    echo -e "\033[0m"
+}
+
 osg_release () {
     osgversion=$1
     sed -r 's/\.[0-9]+$//' <<< $osgversion


### PR DESCRIPTION
This makes it easier to distinguish the header from the text in the emails.

Example:
```
RPMs slated for release in osg-3.4-el6-testing
==============================================
osg-version-3.4.53-1.osg34.el6
xrootd-4.12.3-1.osg34.el6
xrootd-lcmaps-1.7.7-2.osg34.el6
```