### PR TITLE
Updates for new OSG 23 name convention (SOFTWARE-5620)

### DIFF
--- a/0-generate-pkg-list
+++ b/0-generate-pkg-list
@@ -25,9 +25,8 @@ detect_rescue_file
 # # Generate list of packages #
 # #############################
 
-for ver in ${versions[@]}; do
-    branch=$(osg_release $ver)
-    read -ra dvers <<< $(osg_dvers $ver) # create array of dvers
+for branch in ${versions[@]}; do
+    read -ra dvers <<< $(osg_dvers $branch) # create array of dvers
     for dver in ${dvers[@]}; do
         print_header_with_line "RPMs slated for release in osg-$branch-$dver-testing"
         slated_cmd="koji-tag-diff osg-$branch-$dver-{testing,release}"

--- a/0-generate-pkg-list
+++ b/0-generate-pkg-list
@@ -29,7 +29,7 @@ for branch in ${versions[@]}; do
     read -ra dvers <<< $(osg_dvers $branch) # create array of dvers
     for dver in ${dvers[@]}; do
         print_header_with_line "RPMs slated for release in osg-$branch-$dver-testing"
-        slated_cmd="koji-tag-diff osg-$branch-$dver-{testing,release}"
+        slated_cmd="koji-tag-diff osg-$branch-$dver-{testing,$(release_tag_name $branch)}"
         slated=$(eval $slated_cmd | tail -n +2)
         if [[ $DRY_RUN -eq 1 ]]; then
             echo $slated_cmd

--- a/0-generate-pkg-list
+++ b/0-generate-pkg-list
@@ -29,7 +29,7 @@ for branch in ${versions[@]}; do
     read -ra dvers <<< $(osg_dvers $branch) # create array of dvers
     for dver in ${dvers[@]}; do
         print_header_with_line "RPMs slated for release in osg-$branch-$dver-testing"
-        slated_cmd="koji-tag-diff osg-$branch-$dver-{testing,$(release_tag_name $branch)}"
+        slated_cmd="koji-tag-diff osg-$branch-$dver-{testing,release}"
         slated=$(eval $slated_cmd | tail -n +2)
         if [[ $DRY_RUN -eq 1 ]]; then
             echo $slated_cmd

--- a/1-client-tarballs
+++ b/1-client-tarballs
@@ -22,14 +22,13 @@ pushd /tmp
 run_cmd "git clone --depth 1 https://github.com/opensciencegrid/tarball-client"
 
 # Build tarballs
-for ver in ${versions[@]}; do
+for branch in ${versions[@]}; do
     # drop upcoming from versions since they don't get their own tarballs
-    if [[ $ver = *-upcoming ]]; then
+    if [[ $branch = *-upcoming ]]; then
         continue
     fi
-    branch=$(osg_release $ver)
     print_header "Generating $branch tarballs"
-    run_cmd "/tmp/tarball-client/make-client-tarball --osgver=$branch --version=$ver --all --prerelease"
+    run_cmd "/tmp/tarball-client/make-client-tarball --osgver=$branch --version=$(ver_tag $branch) --all --prerelease"
     archs="x86_64"
     for arch in $archs; do
         tarball_dir="tarballs/$branch/$arch"

--- a/1-regen-repos
+++ b/1-regen-repos
@@ -16,7 +16,7 @@ for branch in ${versions[@]}; do
     fi
     read -ra dvers <<< $(osg_dvers $branch) # create array of dvers
     for dver in ${dvers[@]}; do
-        run_cmd "osg-koji regen-repo osg-$branch-$dver-release-build" # avoid pkg 404 errors
+        run_cmd "osg-koji regen-repo osg-$branch-$dver-$(release_tag_name $branch)-build" # avoid pkg 404 errors
     done
 done
 

--- a/1-regen-repos
+++ b/1-regen-repos
@@ -9,13 +9,12 @@ check_for_osg_koji
 
 detect_rescue_file
 
-for ver in ${versions[@]}; do
+for branch in ${versions[@]}; do
     # drop upcoming from versions since they don't get their own tarballs
-    if [[ $ver = *-upcoming ]]; then
+    if [[ $branch = *-upcoming ]]; then
         continue
     fi
-    branch=$(osg_release $ver)
-    read -ra dvers <<< $(osg_dvers $ver) # create array of dvers
+    read -ra dvers <<< $(osg_dvers $branch) # create array of dvers
     for dver in ${dvers[@]}; do
         run_cmd "osg-koji regen-repo osg-$branch-$dver-release-build" # avoid pkg 404 errors
     done

--- a/1-regen-repos
+++ b/1-regen-repos
@@ -16,7 +16,7 @@ for branch in ${versions[@]}; do
     fi
     read -ra dvers <<< $(osg_dvers $branch) # create array of dvers
     for dver in ${dvers[@]}; do
-        run_cmd "osg-koji regen-repo osg-$branch-$dver-$(release_tag_name $branch)-build" # avoid pkg 404 errors
+        run_cmd "osg-koji regen-repo osg-$branch-$dver-release-build" # avoid pkg 404 errors
     done
 done
 

--- a/1-verify-prerelease
+++ b/1-verify-prerelease
@@ -17,9 +17,8 @@ fi
 
 final_msg=""
 
-for ver in ${versions[@]}; do
-    branch=$(osg_release $ver)
-    read -ra dvers <<< $(osg_dvers $ver) # create array of dvers
+for branch in ${versions[@]}; do
+    read -ra dvers <<< $(osg_dvers $branch) # create array of dvers
     for dver in ${dvers[@]}; do
         tag_prefix=osg-$branch-$dver
         prerel_tag=$tag_prefix-prerelease

--- a/1-verify-tarballs
+++ b/1-verify-tarballs
@@ -3,6 +3,7 @@
 . release-common.sh
 
 dotest () {
+    ver=$(ver_tag $branch)
     file=$client-$ver-$data_rel.$rhel.$arch.tar.gz
     if [ -e $file ]; then
         echo "Testing $client-$ver-$data_rel.$rhel.$arch..."
@@ -35,12 +36,11 @@ if [ ! -d $tarball_directory ]; then
 fi
 pushd $tarball_directory
 
-for ver in ${versions[@]}; do
+for branch in ${versions[@]}; do
     # drop upcoming from versions since they don't get their own tarballs
-    if [[ $ver = *-upcoming ]]; then
+    if [[ $branch = *-upcoming ]]; then
         continue
     fi
-    major_version="${ver%.*}"
     rhels="el7 el8"
     clients="osg-wn-client"
     data_rel="1"

--- a/1-verify-tarballs
+++ b/1-verify-tarballs
@@ -41,7 +41,7 @@ for branch in ${versions[@]}; do
     if [[ $branch = *-upcoming ]]; then
         continue
     fi
-    rhels="el7 el8"
+    rhels=$(osg_dvers $branch)
     clients="osg-wn-client"
     data_rel="1"
     if [ $DATA -ne 0 ]; then

--- a/2-push-release
+++ b/2-push-release
@@ -18,7 +18,7 @@ for branch in ${versions[@]}; do
     read -ra dvers <<< $(osg_dvers $branch) # create array of dvers
     for dver in ${dvers[@]}; do
         prerelease_repo=osg-$branch-$dver-prerelease
-        release_repo=osg-$branch-$dver-$(release_tag_name $branch)
+        release_repo=osg-$branch-$dver-release
 
         # Push from pre-release to release
         print_header "Unlocking $release_repo"
@@ -34,7 +34,7 @@ for branch in ${versions[@]}; do
 
         if [ $DATA -eq 0 ]; then
             # Create new release repo for non-$data releases
-            versioned_release_repo=osg-$branch-$dver-$(release_tag_name $branch)-$(ver_tag $branch)
+            versioned_release_repo=osg-$branch-$dver-release-$(ver_tag $branch)
             print_header "Cloning $release_repo to $versioned_release_repo"
             run_cmd "osg-koji clone-tag --all $release_repo $versioned_release_repo"
             echo

--- a/2-push-release
+++ b/2-push-release
@@ -18,7 +18,7 @@ for branch in ${versions[@]}; do
     read -ra dvers <<< $(osg_dvers $branch) # create array of dvers
     for dver in ${dvers[@]}; do
         prerelease_repo=osg-$branch-$dver-prerelease
-        release_repo=osg-$branch-$dver-release
+        release_repo=osg-$branch-$dver-$(release_tag_name $branch)
 
         # Push from pre-release to release
         print_header "Unlocking $release_repo"
@@ -34,7 +34,7 @@ for branch in ${versions[@]}; do
 
         if [ $DATA -eq 0 ]; then
             # Create new release repo for non-$data releases
-            versioned_release_repo=osg-$branch-$dver-release-$(ver_tag $branch)
+            versioned_release_repo=osg-$branch-$dver-$(release_tag_name $branch)-$(ver_tag $branch)
             print_header "Cloning $release_repo to $versioned_release_repo"
             run_cmd "osg-koji clone-tag --all $release_repo $versioned_release_repo"
             echo

--- a/2-push-release
+++ b/2-push-release
@@ -11,12 +11,11 @@ check_for_osg_koji
 
 detect_rescue_file
 
-for ver in ${versions[@]}; do
-    branch=$(osg_release $ver)
+for branch in ${versions[@]}; do
     if [[ $branch = 3.*-upcoming ]]; then
         ver=${ver%-upcoming}
     fi
-    read -ra dvers <<< $(osg_dvers $ver) # create array of dvers
+    read -ra dvers <<< $(osg_dvers $branch) # create array of dvers
     for dver in ${dvers[@]}; do
         prerelease_repo=osg-$branch-$dver-prerelease
         release_repo=osg-$branch-$dver-release
@@ -35,7 +34,7 @@ for ver in ${versions[@]}; do
 
         if [ $DATA -eq 0 ]; then
             # Create new release repo for non-$data releases
-            versioned_release_repo=osg-$branch-$dver-release-$ver
+            versioned_release_repo=osg-$branch-$dver-release-$(ver_tag $branch)
             print_header "Cloning $release_repo to $versioned_release_repo"
             run_cmd "osg-koji clone-tag --all $release_repo $versioned_release_repo"
             echo

--- a/2-update-info
+++ b/2-update-info
@@ -27,12 +27,11 @@ if [[ ! -d /p/vdt/public/html/release-info/ && $DRY_RUN -eq 0 ]]; then
     read rusermachine
 fi
 
-for ver in ${versions[@]}; do
-    branch=$(osg_release $ver)
+for branch in ${versions[@]}; do
     if [[ $branch = 3.*-upcoming ]]; then
         ver=${ver%-upcoming}
     fi
-    read -ra dvers <<< $(osg_dvers $ver) # create array of dvers
+    read -ra dvers <<< $(osg_dvers $branch) # create array of dvers
     for dver in ${dvers[@]}; do
         release_repo=osg-$branch-$dver-release
 
@@ -42,11 +41,13 @@ for ver in ${versions[@]}; do
             data_option="--since " # option for list-package-updates for data releases
         fi
 
+        pkg_prefix=$(ver_tag $branch)$data_rel
+
         if [ -s move-to-$branch-release-$dver ]; then
             # Update info
-            run_cmd "cp move-to-$branch-release-$dver $ver$data_rel-updated-$branch-$dver.txt"
-            run_cmd "osg-koji list-tagged --quiet --latest $release_repo | awk '{print \$1}' > $ver$data_rel-packages-$branch-$dver.txt"
-            run_cmd "xargs --arg-file $ver$data_rel-packages-$branch-$dver.txt osg-koji buildinfo | fgrep \"/mnt\" | xargs -n 1 basename | sort > $ver$data_rel-rpms-$branch$data_rel-$dver.txt"
+            run_cmd "cp move-to-$branch-release-$dver $pkg_prefix-updated-$branch-$dver.txt"
+            run_cmd "osg-koji list-tagged --quiet --latest $release_repo | awk '{print \$1}' > $pkg_prefix-packages-$branch-$dver.txt"
+            run_cmd "xargs --arg-file $pkg_prefix-packages-$branch-$dver.txt osg-koji buildinfo | fgrep \"/mnt\" | xargs -n 1 basename | sort > $pkg_prefix-rpms-$branch$data_rel-$dver.txt"
             echo
         fi
     done

--- a/2-update-info
+++ b/2-update-info
@@ -33,7 +33,7 @@ for branch in ${versions[@]}; do
     fi
     read -ra dvers <<< $(osg_dvers $branch) # create array of dvers
     for dver in ${dvers[@]}; do
-        release_repo=osg-$branch-$dver-release
+        release_repo=osg-$branch-$dver-$(release_tag_name $branch)
 
         print_header "Generating release notes for $release_repo"
         if [ $DATA -ne 0 ]; then

--- a/2-update-info
+++ b/2-update-info
@@ -28,12 +28,9 @@ if [[ ! -d /p/vdt/public/html/release-info/ && $DRY_RUN -eq 0 ]]; then
 fi
 
 for branch in ${versions[@]}; do
-    if [[ $branch = 3.*-upcoming ]]; then
-        ver=${ver%-upcoming}
-    fi
     read -ra dvers <<< $(osg_dvers $branch) # create array of dvers
     for dver in ${dvers[@]}; do
-        release_repo=osg-$branch-$dver-$(release_tag_name $branch)
+        release_repo=osg-$branch-$dver-release
 
         print_header "Generating release notes for $release_repo"
         if [ $DATA -ne 0 ]; then

--- a/2-upload-tarballs-to-afs
+++ b/2-upload-tarballs-to-afs
@@ -14,12 +14,11 @@ if [ ! -d $tarball_src ]; then
     exit 1
 fi
 
-for ver in ${versions[@]}; do
+for branch in ${versions[@]}; do
     # drop upcoming from versions since they don't get their own tarballs
-    if [[ $ver = *-upcoming ]]; then
+    if [[ $branch = *-upcoming ]]; then
         continue
     fi
-    branch=$(osg_release $ver)
     archs="x86_64"
     for arch in $archs; do
         tarball_dest="tarballs/$branch/$arch"

--- a/osg-pkgs-behind-tag
+++ b/osg-pkgs-behind-tag
@@ -35,9 +35,9 @@ show_all  = False
 pkgset    = None
 tags      = []
 
-tagpat = (r'^osg-([3-9]\.[0-9](-upcoming)?)'
-          r'-el[5-9]-(development|testing|release)'
-          r'(-[3-9]\.\d\.\d+)?$')
+tagpat = (r'^osg-(([3-9]\.\d|[2-9]\d)(-upcoming)?)'
+          r'-el[5-9]-(development|testing|(main-)?release)'
+          r'(-([3-9]\.\d|[2-9]\d)\.\d+)?$')
 
 def usage():
     print(__doc__.format(os.path.basename(__file__)))

--- a/release-common.sh
+++ b/release-common.sh
@@ -137,11 +137,12 @@ pkgs_to_release () {
 }
 
 ver_tag () {
-    echo $1.$date_tag
+    # Return major-version.yymmdd
+    echo ${1%-upcoming}.$date_tag
 }
 
 release_tag_name () {
-    # return release for all upcoming and 3.X, main-release for >=23 
+    # return 'release' for *-upcoming and 3.X, 'main-release' for >=23
     branch=$1
     if [[ $1 =~ ^.*-upcoming$ || $1 =~ ^(3\.[56])$ ]]; then 
         echo "release"

--- a/release-common.sh
+++ b/release-common.sh
@@ -140,6 +140,17 @@ ver_tag () {
     echo $1.$date_tag
 }
 
+release_tag_name () {
+    # return release for all upcoming and 3.X, main-release for >=23 
+    branch=$1
+    if [[ $1 =~ ^.*-upcoming$ || $1 =~ ^(3\.[56])$ ]]; then 
+        echo "release"
+    else 
+        echo "main-release"
+    fi
+
+}
+
 ########
 # MAIN #
 ########

--- a/release-common.sh
+++ b/release-common.sh
@@ -6,7 +6,7 @@ die () {
 }
 
 usage () {
-    echo "usage: $script_name [options] <VERSION 1> [<VERSION 2>...<VERSION N>]"
+    echo "usage: $script_name [options] <RELEASE DATE> <VERSION 1> [<VERSION 2>...<VERSION N>]"
     echo "Options:"
     echo -e "\t-d REVISION, --data REVISION\tSpecify the REVISION of the data-only release"
     echo -e "\t-n, --dry-run\t\t\tPrint the commands that would be run"
@@ -31,6 +31,7 @@ osg_dvers () {
     case $branch in
       3.5 | 3.5-upcoming ) echo el7 el8 ;;
       3.6 | 3.6-upcoming ) echo el7 el8 el9 ;;
+       23 |  23-upcoming ) echo el8 el9 ;;
     esac
 }
 


### PR DESCRIPTION
- Update command line args to take date and release version as separate arguments, rather than `<release-version>.<date>`
- Remove some redundancy that came from splitting up `<release-version>.<date>` arg
- Update regexes to accept `3.X` and `release-year >= 23` for release versions
- Update build version tags to reference `main-elX-release` instead of `elX-release` when osg versions is >=23

This is tested to the extent that's possible with `--dry-run` and no OSG 23 RPMs in koji, I expect another round of bugfixing will be necessary once we're actually slated to release though